### PR TITLE
Changed description editor for all object types to be a multiline editor

### DIFF
--- a/TOMWrapper/TOMWrapper/Base/Column.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/Column.generated.cs
@@ -81,7 +81,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the Column.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this Column.")]
+		[Category("Basic"),IntelliSense("The Description of this Column.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/DataSource.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/DataSource.generated.cs
@@ -37,7 +37,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the DataSource.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this DataSource.")]
+		[Category("Basic"),IntelliSense("The Description of this DataSource.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/Hierarchy.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/Hierarchy.generated.cs
@@ -42,7 +42,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the Hierarchy.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this Hierarchy.")]
+		[Category("Basic"),IntelliSense("The Description of this Hierarchy.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/KPI.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/KPI.generated.cs
@@ -37,7 +37,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the KPI.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this KPI.")]
+		[Category("Basic"),IntelliSense("The Description of this KPI.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/Level.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/Level.generated.cs
@@ -64,7 +64,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the Level.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this Level.")]
+		[Category("Basic"),IntelliSense("The Description of this Level.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/Measure.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/Measure.generated.cs
@@ -42,7 +42,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the Measure.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this Measure.")]
+		[Category("Basic"),IntelliSense("The Description of this Measure.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/Model.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/Model.generated.cs
@@ -49,7 +49,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the Model.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this Model.")]
+		[Category("Basic"),IntelliSense("The Description of this Model.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/ModelRole.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/ModelRole.generated.cs
@@ -42,7 +42,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the ModelRole.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this ModelRole.")]
+		[Category("Basic"),IntelliSense("The Description of this ModelRole.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/Partition.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/Partition.generated.cs
@@ -54,7 +54,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the Partition.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this Partition.")]
+		[Category("Basic"),IntelliSense("The Description of this Partition.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/Perspective.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/Perspective.generated.cs
@@ -42,7 +42,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the Perspective.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this Perspective.")]
+		[Category("Basic"),IntelliSense("The Description of this Perspective.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;

--- a/TOMWrapper/TOMWrapper/Base/Rules.ttinclude
+++ b/TOMWrapper/TOMWrapper/Base/Rules.ttinclude
@@ -159,6 +159,7 @@ class Rules {
 		if(className == "Model" && propertyName == "Culture") return "[TypeConverter(typeof(CultureConverter))]";
 		if(propertyName == "DisplayFolder") return "[Editor(typeof(CustomDialogEditor), typeof(System.Drawing.Design.UITypeEditor))]";
 		if(propertyName == "Expression") return "[Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]";
+		if(propertyName == "Description") return "[Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]";
 
 		return "";
     }

--- a/TOMWrapper/TOMWrapper/Base/Table.generated.cs
+++ b/TOMWrapper/TOMWrapper/Base/Table.generated.cs
@@ -64,7 +64,7 @@ namespace TabularEditor.TOMWrapper
         /// Gets or sets the Description of the Table.
         /// </summary>
 		[DisplayName("Description")]
-		[Category("Basic"),IntelliSense("The Description of this Table.")]
+		[Category("Basic"),IntelliSense("The Description of this Table.")][Editor(typeof(System.ComponentModel.Design.MultilineStringEditor), typeof(System.Drawing.Design.UITypeEditor))]
 		public string Description {
 			get {
 			    return MetadataObject.Description;


### PR DESCRIPTION
To make editing descriptions easier, and capable of having new lines, I changed the property to use a multiline ditor.