### PR TITLE
Fix NullReferenceException in ExpressionEditor_GoToDefinition

### DIFF
--- a/TabularEditor/UI/UIController_ExpressionEditor.cs
+++ b/TabularEditor/UI/UIController_ExpressionEditor.cs
@@ -82,7 +82,7 @@ namespace TabularEditor.UI
             }
         }
 
-        private List<Antlr4.Runtime.IToken> currentTokens;
+        private List<Antlr4.Runtime.IToken> currentTokens = new List<Antlr4.Runtime.IToken>();
 
         private void ExpressionEditor_ExpressionSelectorChanged(object sender, EventArgs e)
         {

--- a/TabularEditor/UIServices/FileSystemHelper.cs
+++ b/TabularEditor/UIServices/FileSystemHelper.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security;
+using System.Security.Permissions;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -11,23 +13,9 @@ namespace TabularEditor.UIServices
     {
         public static bool IsDirectoryWritable(string dirPath)
         {
-            try
-            {
-                using (FileStream fs = File.Create(
-                    Path.Combine(
-                        dirPath,
-                        Path.GetRandomFileName()
-                    ),
-                    1,
-                    FileOptions.DeleteOnClose)
-                )
-                { }
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
+            var permissionSet = new PermissionSet(PermissionState.None);
+            permissionSet.AddPermission(perm: new FileIOPermission(FileIOPermissionAccess.Write, dirPath));
+            return permissionSet.IsSubsetOf(AppDomain.CurrentDomain.PermissionSet);
         }
 
         public static string DirectoryFromPath(string filePath)


### PR DESCRIPTION
- Fix `NullReferenceException` in `ExpressionParser.GetTokenAtPos` when tokens parameter is null. As repro steps, open a model, select a table that has no code in the expression editor, press F12.

- Small fix `FileSystemHelper.IsDirectoryWritable` - if the path refers to a missing folder (e.g  `%ProgramData%\TabularEditor` when the app is running for the first time) then the method `System.IO.File.Create` raises a `DirectoryNotFoundException` and sets the result to `false` regardless of the effective permissions for the path. Code changed using `System.Security.PermissionSet`.
