### PR TITLE
Add destination server name to deployment status label

### DIFF
--- a/TabularEditor/UI/UIController_Database.cs
+++ b/TabularEditor/UI/UIController_Database.cs
@@ -68,7 +68,7 @@ namespace TabularEditor.UI
                     MessageBox.Show(message, error ? "Error occured during deployment" : "Deploy cancelled", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
-                UI.StatusLabel.Text = error ? "Deploy failed!" : cancelled ? "Deploy cancelled!" : "Deploy succeeded!";
+                UI.StatusLabel.Text = string.Format(error ? "Deploy failed! {0}" : cancelled ? "Deploy cancelled! {0}" : "Deploy succeeded! {0}", f.DeployTargetServer.Name);
             }
         }
 


### PR DESCRIPTION
On occasion we are deploying to a series of servers concurrently with multiple Tabular Editor windows open.  Knowing which server was successful or not is convenient for us in this scenario.  Submitting as a pull request in case you think others might find it useful. 