### PR TITLE
Fix saving/deploying error "table has two columns with the IsKey property set to True"

### DIFF
--- a/TOMWrapper/TOMWrapper/MetadataObjectHelper.cs
+++ b/TOMWrapper/TOMWrapper/MetadataObjectHelper.cs
@@ -102,5 +102,19 @@ namespace Microsoft.AnalysisServices.Tabular.Helper
                 if (!obj.IsRemoved) obj.Name = newName;
             }
         }    
+
+        public static List<Column> GetDuplictedKeyColumns(this TableCollection tables)
+        {
+            var duplicatedKeyColumns = new List<Column>();
+
+            foreach (var table in tables)
+            {
+                var keyColumns = table.Columns.Where(c => c.IsKey).ToList();
+                if (keyColumns.Count > 1)
+                    duplicatedKeyColumns.AddRange(keyColumns.Where(c => c.Type != ColumnType.RowNumber));
+            }
+
+            return duplicatedKeyColumns;
+        }
     }
 }

--- a/TOMWrapper/TOMWrapper/TabularModelHandler.Database.cs
+++ b/TOMWrapper/TOMWrapper/TabularModelHandler.Database.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.AnalysisServices.Tabular.Helper;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -70,7 +71,14 @@ namespace TabularEditor.TOMWrapper
             //DetachCalculatedTableMetadata();
             try
             {
-                // TODO: Deleting a column with IsKey = true, then undoing, then saving causes an error... Check if this is still the case.
+                var duplicatedKeyColumns = database.Model.Tables.GetDuplictedKeyColumns();
+                if (duplicatedKeyColumns.Any())
+                {
+                    duplicatedKeyColumns.ForEach(c => c.IsKey = false);
+                    database.Model.SaveChanges();
+                    duplicatedKeyColumns.ForEach(c => c.IsKey = true);
+                }
+
                 database.Model.SaveChanges();
 
                 AttachCalculatedTableMetadata();


### PR DESCRIPTION
Hi Daniel, 
this PR include a fix for issue #40, both for saving and deploying.

As far as I know, in order to add a new column with `isKey=true` to an existing table and keep the deployment in a single transaction the only way is to run `delete` operations in batch mode using a `sequence` TMSL command. I have not been able to find a better solution.