### PR TITLE
Fix for connection string containing a double quote

### DIFF
--- a/TOMWrapper/TOMWrapper/TabularConnection.cs
+++ b/TOMWrapper/TOMWrapper/TabularConnection.cs
@@ -15,10 +15,10 @@ namespace TabularEditor.TOMWrapper
 
         public static string GetConnectionString(string serverName, string userName, string password)
         {
-            return string.Format("Provider=MSOLAP;DataSource={0};User ID={1};Password={2};Persist Security Info=True;Impersonation Level=Impersonate;",
+            return string.Format(@"Provider=MSOLAP;DataSource={0};User ID={1};Password=""{2}"";Persist Security Info=True;Impersonation Level=Impersonate;",
                 serverName,
                 userName,
-                password);
+                password.Replace(@"""", @""""""));
         }
     }
 }

--- a/TOMWrapper/TOMWrapper/TabularConnection.cs
+++ b/TOMWrapper/TOMWrapper/TabularConnection.cs
@@ -15,10 +15,10 @@ namespace TabularEditor.TOMWrapper
 
         public static string GetConnectionString(string serverName, string userName, string password)
         {
-            return string.Format(@"Provider=MSOLAP;DataSource={0};User ID={1};Password=""{2}"";Persist Security Info=True;Impersonation Level=Impersonate;",
+            return string.Format("Provider=MSOLAP;DataSource={0};User ID={1};Password=\"{2}\";Persist Security Info=True;Impersonation Level=Impersonate;",
                 serverName,
                 userName,
-                password.Replace(@"""", @""""""));
+                password.Replace("\"", "\"\""));
         }
     }
 }


### PR DESCRIPTION
Details how to handle quotation marks are given at https://docs.microsoft.com/en-us/dotnet/api/system.data.oledb.oledbconnection.connectionstring?view=dotnet-plat-ext-3.1#remarks .
I have tried password containing a = they do not have to be doubled.

This fixes #459 for me. 