### PR TITLE
Scripting - ExportProperties/ImportProperties, added support for TranslationIndexer properties

### DIFF
--- a/TOMWrapper/TOMWrapper/AnnotationCollection.cs
+++ b/TOMWrapper/TOMWrapper/AnnotationCollection.cs
@@ -41,7 +41,10 @@ namespace TabularEditor.TOMWrapper
 
             set
             {
-                Parent.SetAnnotation(index, value.ToString());
+                if (value == null)
+                    Parent.RemoveAnnotation(index);
+                else
+                    Parent.SetAnnotation(index, value.ToString());
             }
         }
 

--- a/TOMWrapper/TOMWrapper/Indexers/PerspectiveIndexer.cs
+++ b/TOMWrapper/TOMWrapper/Indexers/PerspectiveIndexer.cs
@@ -115,7 +115,13 @@ namespace TabularEditor.TOMWrapper
         protected override void SetInPerspective(Perspective perspective, bool included)
         {
             var pts = perspective.MetadataObject.PerspectiveTables;
-            if (included && !pts.Contains(Table.Name)) pts.Add(new Microsoft.AnalysisServices.Tabular.PerspectiveTable() { Table = Table.MetadataObject });
+            if (included)
+            {
+                if (!pts.Contains(Table.Name)) pts.Add(new Microsoft.AnalysisServices.Tabular.PerspectiveTable() { Table = Table.MetadataObject });
+                else return; // If TOM already contains a PerspectiveTable then we don't need to do anything.
+            }
+            if (!included && !pts.Contains(Table.Name))
+                return; // If no PerspectiveTable exists in TOM then we're done.
 
             // Including/excluding a table from a perspective, is equivalent to including/excluding all child
             // objects. The PerspectiveTable will be created automatically if needed.

--- a/TOMWrapper/TOMWrapper/Indexers/TranslationIndexer.cs
+++ b/TOMWrapper/TOMWrapper/Indexers/TranslationIndexer.cs
@@ -36,14 +36,6 @@ namespace TabularEditor.TOMWrapper
             return sb.ToString();
         }
 
-        public void FromJson(string json)
-        {
-            var translations = JObject.Parse(json);
-
-            foreach (var translation in translations.Properties())
-                this[translation.Name] = translation.Value.ToString();
-        }
-
         bool IExpandableIndexer.EnableMultiLine => false;
 
         public Dictionary<string, string> Copy()

--- a/TOMWrapper/TOMWrapper/Indexers/TranslationIndexer.cs
+++ b/TOMWrapper/TOMWrapper/Indexers/TranslationIndexer.cs
@@ -11,7 +11,6 @@ using TabularEditor.PropertyGridUI;
 using TabularEditor.TOMWrapper.Undo;
 using System.Text;
 using System.IO;
-using json::Newtonsoft.Json.Linq;
 
 namespace TabularEditor.TOMWrapper
 {

--- a/TOMWrapper/TOMWrapper/Indexers/TranslationIndexer.cs
+++ b/TOMWrapper/TOMWrapper/Indexers/TranslationIndexer.cs
@@ -11,6 +11,7 @@ using TabularEditor.PropertyGridUI;
 using TabularEditor.TOMWrapper.Undo;
 using System.Text;
 using System.IO;
+using json::Newtonsoft.Json.Linq;
 
 namespace TabularEditor.TOMWrapper
 {
@@ -33,6 +34,14 @@ namespace TabularEditor.TOMWrapper
                 writer.WriteEndObject();
             }
             return sb.ToString();
+        }
+
+        public void FromJson(string json)
+        {
+            var translations = JObject.Parse(json);
+
+            foreach (var translation in translations.Properties())
+                this[translation.Name] = translation.Value.ToString();
         }
 
         bool IExpandableIndexer.EnableMultiLine => false;

--- a/TabularEditor/Scripting/PropertySerializer.cs
+++ b/TabularEditor/Scripting/PropertySerializer.cs
@@ -78,7 +78,7 @@ namespace TabularEditor.Scripting
 
             string ToString(object value)
             {
-                return Convert.ToString(value).Replace("\n", "\\n").Replace("\t", "\\t");
+                return Convert.ToString(value).Replace("\n", "\\n").Replace("\r", "\\r").Replace("\t", "\\t");
             }
         }
 
@@ -135,7 +135,7 @@ namespace TabularEditor.Scripting
 
         private static void AssignTsvToObject(string propertyValues, TsvProperty[] properties)
         {
-            var values = propertyValues.Replace("\r","").Split('\t').Select(v => v.Replace("\\n", "\n").Replace("\\t", "\t")).ToArray();
+            var values = propertyValues.Replace("\r", "").Split('\t').Select(v => v.Replace("\\n", "\n").Replace("\\r", "\r").Replace("\\t", "\t")).ToArray();
             var obj = ResolveObjectPath(values[0]);
             if (obj == null) return;
 

--- a/TabularEditor/Scripting/PropertySerializer.cs
+++ b/TabularEditor/Scripting/PropertySerializer.cs
@@ -62,19 +62,24 @@ namespace TabularEditor.Scripting
                     else if (prop.IsIndexer)
                     {
                         if (pValue is TranslationIndexer translations)
-                            sb.Append(translations.Keys.Contains(prop.Index) ? translations[prop.Index] : string.Empty);
+                            sb.Append(translations.Keys.Contains(prop.Index) ? ToString(translations[prop.Index]) : string.Empty);
                         else if (pValue is PerspectiveIndexer perspectives)
-                            sb.Append(perspectives.Keys.Contains(prop.Index) ? Convert.ToString(perspectives[prop.Index]) : string.Empty);
+                            sb.Append(perspectives.Keys.Contains(prop.Index) ? ToString(perspectives[prop.Index]) : string.Empty);
                         if (pValue is ExtendedPropertyCollection extendedProperties)
-                            sb.Append(extendedProperties.Keys.Contains(prop.Index) ? extendedProperties[prop.Index] : string.Empty);
+                            sb.Append(extendedProperties.Keys.Contains(prop.Index) ? ToString(extendedProperties[prop.Index]) : string.Empty);
                         else if (pValue is AnnotationCollection annotations)
-                            sb.Append(annotations.Keys.Contains(prop.Index) ? annotations[prop.Index] : string.Empty);
+                            sb.Append(annotations.Keys.Contains(prop.Index) ? ToString(annotations[prop.Index]) : string.Empty);
                     }
                     else
-                        sb.Append(pValue.ToString().Replace("\n", "\\n").Replace("\t", "\\t"));
+                        sb.Append(ToString(pValue));
                 }
             }
             return sb.ToString();
+
+            string ToString(object value)
+            {
+                return Convert.ToString(value).Replace("\n", "\\n").Replace("\t", "\\t");
+            }
         }
 
         [ScriptMethod]

--- a/TabularEditor/Scripting/PropertySerializer.cs
+++ b/TabularEditor/Scripting/PropertySerializer.cs
@@ -82,6 +82,7 @@ namespace TabularEditor.Scripting
                 else
                 {
                     var expandedKeys = new List<string>();
+                    var isIndexer = false;
 
                     foreach (var tabularObject in objects)
                     {
@@ -89,17 +90,29 @@ namespace TabularEditor.Scripting
                         if (value != null)
                         {
                             if (value is TranslationIndexer translations)
+                            {
+                                isIndexer = true;
                                 expandedKeys.AddRange(translations.Keys);
+                            }
                             else if (value is PerspectiveIndexer perspectives)
+                            {
+                                isIndexer = true;
                                 expandedKeys.AddRange(perspectives.Keys);
+                            }
                             else if (value is ExtendedPropertyCollection extendedProperties)
+                            {
+                                isIndexer = true;
                                 expandedKeys.AddRange(extendedProperties.Keys);
+                            }
                             else if (value is AnnotationCollection annotations)
+                            {
+                                isIndexer = true;
                                 expandedKeys.AddRange(annotations.Keys);
+                            }
                         }
                     }
 
-                    if (expandedKeys.Any())
+                    if (isIndexer)
                         expandedProperties.AddRange(expandedKeys.Distinct().Select((k) => new Property(property.Name, key: k, isIndexer: true)));
                     else
                         expandedProperties.Add(property);

--- a/TabularEditor/Scripting/PropertySerializer.cs
+++ b/TabularEditor/Scripting/PropertySerializer.cs
@@ -39,6 +39,14 @@ namespace TabularEditor.Scripting
             public string Name { get; }
             public string Key { get; }
             public bool IsIndexer { get; }
+
+            public override string ToString()
+            {
+                if (IsIndexer)
+                    return $"{ Name }[{ Key }]";
+
+                return Name;
+            }
         }
 
         private static Property[] ParseProperties(string header)
@@ -74,7 +82,7 @@ namespace TabularEditor.Scripting
                 else
                 {
                     var expandedKeys = new List<string>();
-                    
+
                     foreach (var tabularObject in objects)
                     {
                         var value = tabularObject.GetType().GetProperty(property.Name)?.GetValue(tabularObject);
@@ -152,15 +160,7 @@ namespace TabularEditor.Scripting
             
             var sb = new StringBuilder();
             sb.Append("Object\t");
-
-            foreach (var property in expandedProperties)
-            {
-                sb.Append(property.Name);
-                if (property.IsIndexer) 
-                    sb.Append($"[{ property.Key }]");
-                if (property != expandedProperties.Last())
-                    sb.Append("\t");
-            }
+            sb.Append(string.Join("\t", expandedProperties.Select(Convert.ToString)));
 
             foreach (var obj in serializableObjects)
             {
@@ -209,8 +209,8 @@ namespace TabularEditor.Scripting
                     else if (typeof(PerspectiveIndexer).IsAssignableFrom(pInfo.PropertyType))
                     {
                         var perspectives = (PerspectiveIndexer)pInfo.GetValue(obj);
-                        if (perspectives.Keys.Contains(properties[i].Key))
-                            perspectives[properties[i].Key] = Convert.ToBoolean(pValue);
+                        if (perspectives.Keys.Contains(properties[i].Key))                        
+                                perspectives[properties[i].Key] = Convert.ToBoolean(pValue);
                     }
                     else if (typeof(ExtendedPropertyCollection).IsAssignableFrom(pInfo.PropertyType) && !string.Empty.Equals(pValue))
                     {

--- a/TabularEditor/Scripting/PropertySerializer.cs
+++ b/TabularEditor/Scripting/PropertySerializer.cs
@@ -88,10 +88,19 @@ namespace TabularEditor.Scripting
                     foreach (var tabularObject in objects)
                     {
                         var value = tabularObject.GetType().GetProperty(property.Name)?.GetValue(tabularObject);
+                        if (value == null) continue; // Ignore non-existing properties, as they could exist on other objects in the collection
+
+                        if (value is ITabularObjectCollection)
+                            throw new Exception($"ExportProperties error: Cannot export property {property.Name} on {tabularObject.ObjectType.GetTypeName()} \"{tabularObject.GetName()}\" since it is a collection.");
+
                         if (value is IExpandableIndexer indexerProperty)
                         {
                             isIndexer = true;
                             expandedKeys.AddRange(indexerProperty.Keys);
+                        }
+                        else if (value != null && value.GetType().IsClass && value.GetType() != typeof(string))
+                        {
+                            throw new Exception($"ExportProperties error: Cannot export property {property.Name} on {tabularObject.ObjectType.GetTypeName()} \"{tabularObject.GetName()}\" since it is a complex object.");
                         }
                     }
 

--- a/TabularEditor/Scripting/PropertySerializer.cs
+++ b/TabularEditor/Scripting/PropertySerializer.cs
@@ -157,7 +157,7 @@ namespace TabularEditor.Scripting
 
             var parsedProperties = ParseProperties(properties);
             var expandedProperties = ExpandProperties(parsedProperties, serializableObjects);
-            
+
             var sb = new StringBuilder();
             sb.Append("Object\t");
             sb.Append(string.Join("\t", expandedProperties.Select(Convert.ToString)));
@@ -204,13 +204,13 @@ namespace TabularEditor.Scripting
                     {
                         var translations = (TranslationIndexer)pInfo.GetValue(obj);
                         if (translations.Keys.Contains(properties[i].Key))
-                            translations[properties[i].Key] = pValue;
+                            translations[properties[i].Key] = string.Empty.Equals(pValue) ? null : pValue;
                     }
                     else if (typeof(PerspectiveIndexer).IsAssignableFrom(pInfo.PropertyType))
                     {
                         var perspectives = (PerspectiveIndexer)pInfo.GetValue(obj);
-                        if (perspectives.Keys.Contains(properties[i].Key))                        
-                                perspectives[properties[i].Key] = Convert.ToBoolean(pValue);
+                        if (perspectives.Keys.Contains(properties[i].Key))
+                            perspectives[properties[i].Key] = Convert.ToBoolean(pValue);
                     }
                     else if (typeof(ExtendedPropertyCollection).IsAssignableFrom(pInfo.PropertyType) && !string.Empty.Equals(pValue))
                     {
@@ -293,7 +293,7 @@ namespace TabularEditor.Scripting
                 }
             }
             parts = partsFixed.ToArray();
-            
+
             var model = TabularModelHandler.Singleton.Model;
             if (model == null || parts.Length == 0) return null;
             if (parts.Length == 1 && parts[0] == "model") return model;


### PR DESCRIPTION
Hi Daniel,
This PR is for #434 and allows to export and import TranslationIndexer properties by using two different syntax for property name as the 2nd argument to `ExportProperties` method.

The first one extract values for all cultures within the Model as JSON object:
```
Output(ExportProperties(Selected,"TranslatedNames"));

Object	TranslatedNames
Model.table1	{"en-US":"English Name","it-IT":"Italian Name"}
```
The second allows extract values for a single culture:
```
Output(ExportProperties(Selected,"TranslatedNames[it-IT],TranslatedNames[en-US]"));

Object	TranslatedNames[it-IT]	TranslatedNames[en-US]
Model.table1	Italian Name	English Name
```

Let me know if you hit any problems and if it works for you.
Alberto