### PR TITLE
Fix Cannot unselect when selecting objects with Ctrl + mouse (issue 228)

### DIFF
--- a/TabularEditor/TreeViewAdv/Tree/Input/InputWithControl.cs
+++ b/TabularEditor/TreeViewAdv/Tree/Input/InputWithControl.cs
@@ -1,14 +1,53 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Windows.Forms;
 
 namespace Aga.Controls.Tree
 {
 	internal class InputWithControl: NormalInputState
 	{
+		private bool _mouseDownFlag = false;
+
 		public InputWithControl(TreeViewAdv tree): base(tree)
 		{
 		}
+
+		public override void MouseDown(TreeNodeAdvMouseEventArgs args)
+		{
+			if (args.Node != null)
+			{
+				if (args.Button == MouseButtons.Left || args.Button == MouseButtons.Right)
+				{
+					if (args.Node.IsSelected)
+					{
+						_mouseDownFlag = true;
+						return;
+					}
+					else
+						_mouseDownFlag = false;
+				}
+			}
+
+			base.MouseDown(args);
+		}
+
+		public override void MouseUp(TreeNodeAdvMouseEventArgs args)
+		{
+			Tree.ItemDragMode = false;
+			if (_mouseDownFlag && args.Node != null)
+			{
+				if (_mouseDownFlag && args.Button == MouseButtons.Left)
+					DoMouseOperation(args, false);
+
+				_mouseDownFlag = false;
+			}
+			else
+			{
+				base.MouseUp(args);
+			}
+		}
+
 
 		protected override void DoMouseOperation(TreeNodeAdvMouseEventArgs args, bool focusOnly)
 		{


### PR DESCRIPTION
Hi,
This PR includes a fix for issue #228 by adding custom mousedown & mouseup handling to InputWithControl handler.
Unselecting items from the tree is now possible with ctrl-key down. Focus-mode is untouched, so drag-and-drop works as before.