### PR TITLE
Minor fix - TOMWrapper project does not use Antlr4.Runtime from NuGet

### DIFF
--- a/TOMWrapper/TOMWrapper.csproj
+++ b/TOMWrapper/TOMWrapper.csproj
@@ -37,11 +37,9 @@
     <DocumentationFile>bin\Release\TOMWrapper.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Antlr4.Runtime">
-      <HintPath>..\packages\Antlr4.Runtime.4.5.3\lib\net45\Antlr4.Runtime.dll</HintPath>
+    <Reference Include="Antlr4.Runtime, Version=4.6.0.0, Culture=neutral, PublicKeyToken=09abb75b9ed49849, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr4.Runtime.4.6.6\lib\net45\Antlr4.Runtime.dll</HintPath>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="Microsoft.AnalysisServices.Core, Version=19.10.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AnalysisServices.retail.amd64.19.10.0\lib\net45\Microsoft.AnalysisServices.Core.dll</HintPath>
     </Reference>

--- a/TOMWrapper/packages.config
+++ b/TOMWrapper/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Antlr4.Runtime" version="4.6.6" targetFramework="net46" />
   <package id="Microsoft.AnalysisServices.retail.amd64" version="19.10.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Hi Daniel,
the version of the Antlr4.Runtime package for the TOMWrapper project is not aligned with the version used in the solution (4.6.6).
TOMWrapper does not use Antlr4.Runtime from NuGet but references a local assembly from an old version (4.5.3)