### PR TITLE
Update release history and add relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tabular Editor is a tool that lets you easily manipulate and manage measures, ca
 
 ![](https://raw.githubusercontent.com/otykier/TabularEditor/master/Documentation/Main%20UI%202_1.png)
 
-* [Download Latest Tabular Editor for SQL Server 2016, 2017, 2019 or Azure Analysis Services](https://github.com/otykier/TabularEditor/releases/latest)
+* [Download Latest Tabular Editor for SQL Server 2016, 2017, 2019 or Azure Analysis Services](../../../releases/latest)
 
 Tabular Editor, when downloaded from GitHub, is digitally signed. The certificate is kindly funded by [Kapacity A/S](https://www.kapacity.dk).
 
@@ -13,18 +13,18 @@ Tabular Editor, when downloaded from GitHub, is digitally signed. The certificat
 View the article on www.kapacity.dk/tabular-editor for a general presentation of the tool and the motivations behind it.
 
 * [Webinar: Boosting SSAS Productivity using Tabular Editor](https://www.youtube.com/watch?v=UENChJ_IfRw&feature=youtu.be&t=453)
-* [Getting Started](https://github.com/otykier/TabularEditor/wiki/Getting-Started)
-* [Features at a Glance](https://github.com/otykier/TabularEditor/wiki/Features-at-a-glance)
-* [Advanced Features](https://github.com/otykier/TabularEditor/wiki/Advanced-Features)
-* [Advanced Scripting](https://github.com/otykier/TabularEditor/wiki/Advanced-Scripting)
-* [FAQ](https://github.com/otykier/TabularEditor/wiki/FAQ)
+* [Getting Started](../../../wiki/Getting-Started)
+* [Features at a Glance](../../../wiki/Features-at-a-glance)
+* [Advanced Features](../../../wiki/Advanced-Features)
+* [Advanced Scripting](../../../wiki/Advanced-Scripting)
+* [FAQ](../../../wiki/FAQ)
 
 ## Version History
 
-* **2020-11-25** [Version 2.13.1](https://github.com/otykier/TabularEditor/releases/tag/2.13.1) released (digitally signed)
-* **2020-11-16** [Version 2.13.0](https://github.com/otykier/TabularEditor/releases/tag/2.13.0) released (digitally signed)
+* **2020-11-25** [Version 2.13.1](../../../releases/tag/2.13.1) released (digitally signed)
+* **2020-11-16** [Version 2.13.0](../../../releases/tag/2.13.0) released (digitally signed)
 
-[Full version history](https://github.com/otykier/TabularEditor/blob/master/VersionHistory.md)
+[Full version history](/VersionHistory.md)
 
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -21,51 +21,10 @@ View the article on www.kapacity.dk/tabular-editor for a general presentation of
 
 ## Version History
 
-* **2016-09-01** Version 1.0 released on Kapacity.dk
-* **2016-11-22** Version 2.0 and source code released on GitHub.com
-* **2017-01-13** [Version 2.1](https://github.com/otykier/TabularEditor/releases/tag/2.1.6229) released
-* **2017-01-16** [Version 2.1 for SQL Server vNext](https://github.com/otykier/TabularEditor/releases/tag/2.1.6229-vNext) released
-* **2017-01-20** Various bugfixes to [Version 2.1](https://github.com/otykier/TabularEditor/releases/tag/2.1.6229)
-* **2017-01-31** [Version 2.2](https://github.com/otykier/TabularEditor/releases/tag/2.2.6260) released
-* **2017-02-20** Various bugfixes and improvements to [Version 2.2](https://github.com/otykier/TabularEditor/releases/tag/2.2.6260)
-* **2017-04-22** [Version 2.3](https://github.com/otykier/TabularEditor/releases/tag/2.3.6320) released with support for [SQL Server 2017](https://github.com/otykier/TabularEditor/releases/tag/2.3.6320-CL1400).
-* **2017-05-02** Various bugfixes and improvements to [Version 2.3](https://github.com/otykier/TabularEditor/releases/tag/2.3.6331).
-* **2017-06-30** [Version 2.4](https://github.com/otykier/TabularEditor/releases/tag/2.4) released
-* **2017-08-07** [Version 2.5](https://github.com/otykier/TabularEditor/releases/tag/2.5) released
-* **2017-10-06** [Version 2.6](https://github.com/otykier/TabularEditor/releases/tag/2.6) released
-* **2017-10-10** Improved Installer that will automatically download the prerequisite AMO libs.
-* **2018-02-22** [Version 2.7](https://github.com/otykier/TabularEditor/releases/tag/2.7) released
-* **2018-04-18** [Version 2.7.1](https://github.com/otykier/TabularEditor/releases/tag/2.7.1) released
-* **2018-06-15** [Version 2.7.2](https://github.com/otykier/TabularEditor/releases/tag/2.7.2) released
-* **2018-08-27** [Version 2.7.3](https://github.com/otykier/TabularEditor/releases/tag/2.7.3) released
-* **2018-10-05** [Version 2.7.4](https://github.com/otykier/TabularEditor/releases/tag/2.7.4) released
-* **2019-01-23** [Version 2.8](https://github.com/otykier/TabularEditor/releases/tag/2.8) released
-* **2019-03-01** [Version 2.8.1](https://github.com/otykier/TabularEditor/releases/tag/2.8.1) released
-* **2019-04-19** [Version 2.8.2](https://github.com/otykier/TabularEditor/releases/tag/2.8.2) released
-* **2019-05-16** [Version 2.8.3](https://github.com/otykier/TabularEditor/releases/tag/2.8.3) released
-* **2019-07-30** [Version 2.8.4](https://github.com/otykier/TabularEditor/releases/tag/2.8.4) released
-* **2019-08-14** [Version 2.8.5](https://github.com/otykier/TabularEditor/releases/tag/2.8.5) released
-* **2019-10-16** [Version 2.8.6](https://github.com/otykier/TabularEditor/releases/tag/2.8.6) released
-* **2019-12-07** [Version 2.9.0](https://github.com/otykier/TabularEditor/releases/tag/2.9.0) released
-* **2019-12-09** [Version 2.9.1](https://github.com/otykier/TabularEditor/releases/tag/2.9.1) released
-* **2020-02-06** [Version 2.9.2](https://github.com/otykier/TabularEditor/releases/tag/2.9.2) released
-* **2020-03-06** [Version 2.9.3](https://github.com/otykier/TabularEditor/releases/tag/2.9.3) released
-* **2020-03-09** [Version 2.9.4](https://github.com/otykier/TabularEditor/releases/tag/2.9.4) released
-* **2020-03-12** [Version 2.9.5](https://github.com/otykier/TabularEditor/releases/tag/2.9.5) released
-* **2020-03-30** [Version 2.9.6](https://github.com/otykier/TabularEditor/releases/tag/2.9.6) released
-* **2020-04-02** [Version 2.9.7](https://github.com/otykier/TabularEditor/releases/tag/2.9.7) released
-* **2020-05-03** [Version 2.9.8](https://github.com/otykier/TabularEditor/releases/tag/2.9.8) released (digitally signed)
-* **2020-06-04** [Version 2.10.0](https://github.com/otykier/TabularEditor/releases/tag/2.10.0) released (digitally signed)
-* **2020-06-20** [Version 2.11.0](https://github.com/otykier/TabularEditor/releases/tag/2.11.0) released (digitally signed)
-* **2020-06-24** [Version 2.11.1](https://github.com/otykier/TabularEditor/releases/tag/2.11.1) released (digitally signed)
-* **2020-06-25** [Version 2.11.2](https://github.com/otykier/TabularEditor/releases/tag/2.11.2) released (digitally signed)
-* **2020-06-26** [Version 2.11.3](https://github.com/otykier/TabularEditor/releases/tag/2.11.3) released (digitally signed)
-* **2020-06-26** [Version 2.11.4](https://github.com/otykier/TabularEditor/releases/tag/2.11.4) released (digitally signed)
-* **2020-06-30** [Version 2.11.5](https://github.com/otykier/TabularEditor/releases/tag/2.11.5) released (digitally signed)
-* **2020-07-12** [Version 2.11.6](https://github.com/otykier/TabularEditor/releases/tag/2.11.6) released (digitally signed)
-* **2020-07-31** [Version 2.11.7](https://github.com/otykier/TabularEditor/releases/tag/2.11.7) released (digitally signed)
-* **2020-08-24** [Version 2.12.0](https://github.com/otykier/TabularEditor/releases/tag/2.12.0) released (digitally signed)
-* **2020-08-29** [Version 2.12.1](https://github.com/otykier/TabularEditor/releases/tag/2.12.1) released (digitally signed)
+* **2020-11-25** [Version 2.13.1](https://github.com/otykier/TabularEditor/releases/tag/2.13.1) released (digitally signed)
+* **2020-11-16** [Version 2.13.0](https://github.com/otykier/TabularEditor/releases/tag/2.13.0) released (digitally signed)
+
+[Full version history](https://github.com/otykier/TabularEditor/blob/master/VersionHistory.md)
 
 
 ## Roadmap

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,0 +1,66 @@
+# Version History
+
+## 1.0 - 2.6
+
+* **2016-09-01** Version 1.0 released on Kapacity.dk
+* **2016-11-22** Version 2.0 and source code released on GitHub.com
+* **2017-01-13** [Version 2.1](https://github.com/otykier/TabularEditor/releases/tag/2.1.6229) released
+* **2017-01-16** [Version 2.1 for SQL Server vNext](https://github.com/otykier/TabularEditor/releases/tag/2.1.6229-vNext) released
+* **2017-01-20** Various bugfixes to [Version 2.1](https://github.com/otykier/TabularEditor/releases/tag/2.1.6229)
+* **2017-01-31** [Version 2.2](https://github.com/otykier/TabularEditor/releases/tag/2.2.6260) released
+* **2017-02-20** Various bugfixes and improvements to [Version 2.2](https://github.com/otykier/TabularEditor/releases/tag/2.2.6260)
+* **2017-04-22** [Version 2.3](https://github.com/otykier/TabularEditor/releases/tag/2.3.6320) released with support for [SQL Server 2017](https://github.com/otykier/TabularEditor/releases/tag/2.3.6320-CL1400).
+* **2017-05-02** Various bugfixes and improvements to [Version 2.3](https://github.com/otykier/TabularEditor/releases/tag/2.3.6331).
+* **2017-06-30** [Version 2.4](https://github.com/otykier/TabularEditor/releases/tag/2.4) released
+* **2017-08-07** [Version 2.5](https://github.com/otykier/TabularEditor/releases/tag/2.5) released
+* **2017-10-06** [Version 2.6](https://github.com/otykier/TabularEditor/releases/tag/2.6) released
+* **2017-10-10** Improved Installer that will automatically download the prerequisite AMO libs.
+
+## 2.7.X
+* **2018-02-22** [Version 2.7](https://github.com/otykier/TabularEditor/releases/tag/2.7) released
+* **2018-04-18** [Version 2.7.1](https://github.com/otykier/TabularEditor/releases/tag/2.7.1) released
+* **2018-06-15** [Version 2.7.2](https://github.com/otykier/TabularEditor/releases/tag/2.7.2) released
+* **2018-08-27** [Version 2.7.3](https://github.com/otykier/TabularEditor/releases/tag/2.7.3) released
+* **2018-10-05** [Version 2.7.4](https://github.com/otykier/TabularEditor/releases/tag/2.7.4) released
+
+## 2.8.X
+* **2019-01-23** [Version 2.8](https://github.com/otykier/TabularEditor/releases/tag/2.8) released
+* **2019-03-01** [Version 2.8.1](https://github.com/otykier/TabularEditor/releases/tag/2.8.1) released
+* **2019-04-19** [Version 2.8.2](https://github.com/otykier/TabularEditor/releases/tag/2.8.2) released
+* **2019-05-16** [Version 2.8.3](https://github.com/otykier/TabularEditor/releases/tag/2.8.3) released
+* **2019-07-30** [Version 2.8.4](https://github.com/otykier/TabularEditor/releases/tag/2.8.4) released
+* **2019-08-14** [Version 2.8.5](https://github.com/otykier/TabularEditor/releases/tag/2.8.5) released
+* **2019-10-16** [Version 2.8.6](https://github.com/otykier/TabularEditor/releases/tag/2.8.6) released
+
+## 2.9.X
+* **2019-12-07** [Version 2.9.0](https://github.com/otykier/TabularEditor/releases/tag/2.9.0) released
+* **2019-12-09** [Version 2.9.1](https://github.com/otykier/TabularEditor/releases/tag/2.9.1) released
+* **2020-02-06** [Version 2.9.2](https://github.com/otykier/TabularEditor/releases/tag/2.9.2) released
+* **2020-03-06** [Version 2.9.3](https://github.com/otykier/TabularEditor/releases/tag/2.9.3) released
+* **2020-03-09** [Version 2.9.4](https://github.com/otykier/TabularEditor/releases/tag/2.9.4) released
+* **2020-03-12** [Version 2.9.5](https://github.com/otykier/TabularEditor/releases/tag/2.9.5) released
+* **2020-03-30** [Version 2.9.6](https://github.com/otykier/TabularEditor/releases/tag/2.9.6) released
+* **2020-04-02** [Version 2.9.7](https://github.com/otykier/TabularEditor/releases/tag/2.9.7) released
+* **2020-05-03** [Version 2.9.8](https://github.com/otykier/TabularEditor/releases/tag/2.9.8) released (digitally signed)
+
+## 2.10.X - 2.11.X
+* **2020-06-04** [Version 2.10.0](https://github.com/otykier/TabularEditor/releases/tag/2.10.0) released (digitally signed)
+* **2020-06-20** [Version 2.11.0](https://github.com/otykier/TabularEditor/releases/tag/2.11.0) released (digitally signed)
+* **2020-06-24** [Version 2.11.1](https://github.com/otykier/TabularEditor/releases/tag/2.11.1) released (digitally signed)
+* **2020-06-25** [Version 2.11.2](https://github.com/otykier/TabularEditor/releases/tag/2.11.2) released (digitally signed)
+* **2020-06-26** [Version 2.11.3](https://github.com/otykier/TabularEditor/releases/tag/2.11.3) released (digitally signed)
+* **2020-06-26** [Version 2.11.4](https://github.com/otykier/TabularEditor/releases/tag/2.11.4) released (digitally signed)
+* **2020-06-30** [Version 2.11.5](https://github.com/otykier/TabularEditor/releases/tag/2.11.5) released (digitally signed)
+* **2020-07-12** [Version 2.11.6](https://github.com/otykier/TabularEditor/releases/tag/2.11.6) released (digitally signed)
+* **2020-07-31** [Version 2.11.7](https://github.com/otykier/TabularEditor/releases/tag/2.11.7) released (digitally signed)
+
+## 2.12.X
+* **2020-08-24** [Version 2.12.0](https://github.com/otykier/TabularEditor/releases/tag/2.12.0) released (digitally signed)
+* **2020-08-29** [Version 2.12.1](https://github.com/otykier/TabularEditor/releases/tag/2.12.1) released (digitally signed)
+* **2020-09-08** [Version 2.12.2](https://github.com/otykier/TabularEditor/releases/tag/2.12.2) released (digitally signed)
+* **2020-09-11** [Version 2.12.3](https://github.com/otykier/TabularEditor/releases/tag/2.12.3) released (digitally signed)
+* **2020-09-15** [Version 2.12.4](https://github.com/otykier/TabularEditor/releases/tag/2.12.4) released (digitally signed)
+
+## 2.13.X
+* **2020-11-25** [Version 2.13.1](https://github.com/otykier/TabularEditor/releases/tag/2.13.1) released (digitally signed)
+* **2020-11-16** [Version 2.13.0](https://github.com/otykier/TabularEditor/releases/tag/2.13.0) released (digitally signed)

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -4,63 +4,63 @@
 
 * **2016-09-01** Version 1.0 released on Kapacity.dk
 * **2016-11-22** Version 2.0 and source code released on GitHub.com
-* **2017-01-13** [Version 2.1](https://github.com/otykier/TabularEditor/releases/tag/2.1.6229) released
-* **2017-01-16** [Version 2.1 for SQL Server vNext](https://github.com/otykier/TabularEditor/releases/tag/2.1.6229-vNext) released
-* **2017-01-20** Various bugfixes to [Version 2.1](https://github.com/otykier/TabularEditor/releases/tag/2.1.6229)
-* **2017-01-31** [Version 2.2](https://github.com/otykier/TabularEditor/releases/tag/2.2.6260) released
-* **2017-02-20** Various bugfixes and improvements to [Version 2.2](https://github.com/otykier/TabularEditor/releases/tag/2.2.6260)
-* **2017-04-22** [Version 2.3](https://github.com/otykier/TabularEditor/releases/tag/2.3.6320) released with support for [SQL Server 2017](https://github.com/otykier/TabularEditor/releases/tag/2.3.6320-CL1400).
-* **2017-05-02** Various bugfixes and improvements to [Version 2.3](https://github.com/otykier/TabularEditor/releases/tag/2.3.6331).
-* **2017-06-30** [Version 2.4](https://github.com/otykier/TabularEditor/releases/tag/2.4) released
-* **2017-08-07** [Version 2.5](https://github.com/otykier/TabularEditor/releases/tag/2.5) released
-* **2017-10-06** [Version 2.6](https://github.com/otykier/TabularEditor/releases/tag/2.6) released
+* **2017-01-13** [Version 2.1](../../../releases/tag/2.1.6229) released
+* **2017-01-16** [Version 2.1 for SQL Server vNext](../../../releases/tag/2.1.6229-vNext) released
+* **2017-01-20** Various bugfixes to [Version 2.1](../../../releases/tag/2.1.6229)
+* **2017-01-31** [Version 2.2](../../../releases/tag/2.2.6260) released
+* **2017-02-20** Various bugfixes and improvements to [Version 2.2](../../../releases/tag/2.2.6260)
+* **2017-04-22** [Version 2.3](../../../releases/tag/2.3.6320) released with support for [SQL Server 2017](../../../releases/tag/2.3.6320-CL1400).
+* **2017-05-02** Various bugfixes and improvements to [Version 2.3](../../../releases/tag/2.3.6331).
+* **2017-06-30** [Version 2.4](../../../releases/tag/2.4) released
+* **2017-08-07** [Version 2.5](../../../releases/tag/2.5) released
+* **2017-10-06** [Version 2.6](../../../releases/tag/2.6) released
 * **2017-10-10** Improved Installer that will automatically download the prerequisite AMO libs.
 
 ## 2.7.X
-* **2018-02-22** [Version 2.7](https://github.com/otykier/TabularEditor/releases/tag/2.7) released
-* **2018-04-18** [Version 2.7.1](https://github.com/otykier/TabularEditor/releases/tag/2.7.1) released
-* **2018-06-15** [Version 2.7.2](https://github.com/otykier/TabularEditor/releases/tag/2.7.2) released
-* **2018-08-27** [Version 2.7.3](https://github.com/otykier/TabularEditor/releases/tag/2.7.3) released
-* **2018-10-05** [Version 2.7.4](https://github.com/otykier/TabularEditor/releases/tag/2.7.4) released
+* **2018-02-22** [Version 2.7](../../../releases/tag/2.7) released
+* **2018-04-18** [Version 2.7.1](../../../releases/tag/2.7.1) released
+* **2018-06-15** [Version 2.7.2](../../../releases/tag/2.7.2) released
+* **2018-08-27** [Version 2.7.3](../../../releases/tag/2.7.3) released
+* **2018-10-05** [Version 2.7.4](../../../releases/tag/2.7.4) released
 
 ## 2.8.X
-* **2019-01-23** [Version 2.8](https://github.com/otykier/TabularEditor/releases/tag/2.8) released
-* **2019-03-01** [Version 2.8.1](https://github.com/otykier/TabularEditor/releases/tag/2.8.1) released
-* **2019-04-19** [Version 2.8.2](https://github.com/otykier/TabularEditor/releases/tag/2.8.2) released
-* **2019-05-16** [Version 2.8.3](https://github.com/otykier/TabularEditor/releases/tag/2.8.3) released
-* **2019-07-30** [Version 2.8.4](https://github.com/otykier/TabularEditor/releases/tag/2.8.4) released
-* **2019-08-14** [Version 2.8.5](https://github.com/otykier/TabularEditor/releases/tag/2.8.5) released
-* **2019-10-16** [Version 2.8.6](https://github.com/otykier/TabularEditor/releases/tag/2.8.6) released
+* **2019-01-23** [Version 2.8](../../../releases/tag/2.8) released
+* **2019-03-01** [Version 2.8.1](../../../releases/tag/2.8.1) released
+* **2019-04-19** [Version 2.8.2](../../../releases/tag/2.8.2) released
+* **2019-05-16** [Version 2.8.3](../../../releases/tag/2.8.3) released
+* **2019-07-30** [Version 2.8.4](../../../releases/tag/2.8.4) released
+* **2019-08-14** [Version 2.8.5](../../../releases/tag/2.8.5) released
+* **2019-10-16** [Version 2.8.6](../../../releases/tag/2.8.6) released
 
 ## 2.9.X
-* **2019-12-07** [Version 2.9.0](https://github.com/otykier/TabularEditor/releases/tag/2.9.0) released
-* **2019-12-09** [Version 2.9.1](https://github.com/otykier/TabularEditor/releases/tag/2.9.1) released
-* **2020-02-06** [Version 2.9.2](https://github.com/otykier/TabularEditor/releases/tag/2.9.2) released
-* **2020-03-06** [Version 2.9.3](https://github.com/otykier/TabularEditor/releases/tag/2.9.3) released
-* **2020-03-09** [Version 2.9.4](https://github.com/otykier/TabularEditor/releases/tag/2.9.4) released
-* **2020-03-12** [Version 2.9.5](https://github.com/otykier/TabularEditor/releases/tag/2.9.5) released
-* **2020-03-30** [Version 2.9.6](https://github.com/otykier/TabularEditor/releases/tag/2.9.6) released
-* **2020-04-02** [Version 2.9.7](https://github.com/otykier/TabularEditor/releases/tag/2.9.7) released
-* **2020-05-03** [Version 2.9.8](https://github.com/otykier/TabularEditor/releases/tag/2.9.8) released (digitally signed)
+* **2019-12-07** [Version 2.9.0](../../../releases/tag/2.9.0) released
+* **2019-12-09** [Version 2.9.1](../../../releases/tag/2.9.1) released
+* **2020-02-06** [Version 2.9.2](../../../releases/tag/2.9.2) released
+* **2020-03-06** [Version 2.9.3](../../../releases/tag/2.9.3) released
+* **2020-03-09** [Version 2.9.4](../../../releases/tag/2.9.4) released
+* **2020-03-12** [Version 2.9.5](../../../releases/tag/2.9.5) released
+* **2020-03-30** [Version 2.9.6](../../../releases/tag/2.9.6) released
+* **2020-04-02** [Version 2.9.7](../../../releases/tag/2.9.7) released
+* **2020-05-03** [Version 2.9.8](../../../releases/tag/2.9.8) released (digitally signed)
 
 ## 2.10.X - 2.11.X
-* **2020-06-04** [Version 2.10.0](https://github.com/otykier/TabularEditor/releases/tag/2.10.0) released (digitally signed)
-* **2020-06-20** [Version 2.11.0](https://github.com/otykier/TabularEditor/releases/tag/2.11.0) released (digitally signed)
-* **2020-06-24** [Version 2.11.1](https://github.com/otykier/TabularEditor/releases/tag/2.11.1) released (digitally signed)
-* **2020-06-25** [Version 2.11.2](https://github.com/otykier/TabularEditor/releases/tag/2.11.2) released (digitally signed)
-* **2020-06-26** [Version 2.11.3](https://github.com/otykier/TabularEditor/releases/tag/2.11.3) released (digitally signed)
-* **2020-06-26** [Version 2.11.4](https://github.com/otykier/TabularEditor/releases/tag/2.11.4) released (digitally signed)
-* **2020-06-30** [Version 2.11.5](https://github.com/otykier/TabularEditor/releases/tag/2.11.5) released (digitally signed)
-* **2020-07-12** [Version 2.11.6](https://github.com/otykier/TabularEditor/releases/tag/2.11.6) released (digitally signed)
-* **2020-07-31** [Version 2.11.7](https://github.com/otykier/TabularEditor/releases/tag/2.11.7) released (digitally signed)
+* **2020-06-04** [Version 2.10.0](../../../releases/tag/2.10.0) released (digitally signed)
+* **2020-06-20** [Version 2.11.0](../../../releases/tag/2.11.0) released (digitally signed)
+* **2020-06-24** [Version 2.11.1](../../../releases/tag/2.11.1) released (digitally signed)
+* **2020-06-25** [Version 2.11.2](../../../releases/tag/2.11.2) released (digitally signed)
+* **2020-06-26** [Version 2.11.3](../../../releases/tag/2.11.3) released (digitally signed)
+* **2020-06-26** [Version 2.11.4](../../../releases/tag/2.11.4) released (digitally signed)
+* **2020-06-30** [Version 2.11.5](../../../releases/tag/2.11.5) released (digitally signed)
+* **2020-07-12** [Version 2.11.6](../../../releases/tag/2.11.6) released (digitally signed)
+* **2020-07-31** [Version 2.11.7](../../../releases/tag/2.11.7) released (digitally signed)
 
 ## 2.12.X
-* **2020-08-24** [Version 2.12.0](https://github.com/otykier/TabularEditor/releases/tag/2.12.0) released (digitally signed)
-* **2020-08-29** [Version 2.12.1](https://github.com/otykier/TabularEditor/releases/tag/2.12.1) released (digitally signed)
-* **2020-09-08** [Version 2.12.2](https://github.com/otykier/TabularEditor/releases/tag/2.12.2) released (digitally signed)
-* **2020-09-11** [Version 2.12.3](https://github.com/otykier/TabularEditor/releases/tag/2.12.3) released (digitally signed)
-* **2020-09-15** [Version 2.12.4](https://github.com/otykier/TabularEditor/releases/tag/2.12.4) released (digitally signed)
+* **2020-08-24** [Version 2.12.0](../../../releases/tag/2.12.0) released (digitally signed)
+* **2020-08-29** [Version 2.12.1](../../../releases/tag/2.12.1) released (digitally signed)
+* **2020-09-08** [Version 2.12.2](../../../releases/tag/2.12.2) released (digitally signed)
+* **2020-09-11** [Version 2.12.3](../../../releases/tag/2.12.3) released (digitally signed)
+* **2020-09-15** [Version 2.12.4](../../../releases/tag/2.12.4) released (digitally signed)
 
 ## 2.13.X
-* **2020-11-25** [Version 2.13.1](https://github.com/otykier/TabularEditor/releases/tag/2.13.1) released (digitally signed)
-* **2020-11-16** [Version 2.13.0](https://github.com/otykier/TabularEditor/releases/tag/2.13.0) released (digitally signed)
+* **2020-11-25** [Version 2.13.1](../../../releases/tag/2.13.1) released (digitally signed)
+* **2020-11-16** [Version 2.13.0](../../../releases/tag/2.13.0) released (digitally signed)


### PR DESCRIPTION
Split version history to new file for older releases
Updated readme to have version history reverse chronologically for current X.X release.
Migrated to relative links.