### PR TITLE
Improved default selection in the deployment wizard

### DIFF
--- a/TabularEditor/UI/Dialogs/Pages/DatabasePage.cs
+++ b/TabularEditor/UI/Dialogs/Pages/DatabasePage.cs
@@ -11,6 +11,7 @@ using Microsoft.AnalysisServices.Tabular;
 using System.Globalization;
 using TabularEditor.UIServices;
 using System.Threading;
+using Microsoft.AnalysisServices;
 
 namespace TabularEditor.UI.Dialogs.Pages
 {

--- a/TabularEditor/UI/Dialogs/Pages/DatabasePage.cs
+++ b/TabularEditor/UI/Dialogs/Pages/DatabasePage.cs
@@ -11,7 +11,6 @@ using Microsoft.AnalysisServices.Tabular;
 using System.Globalization;
 using TabularEditor.UIServices;
 using System.Threading;
-using Microsoft.AnalysisServices;
 
 namespace TabularEditor.UI.Dialogs.Pages
 {

--- a/TabularEditor/UI/UIController.cs
+++ b/TabularEditor/UI/UIController.cs
@@ -2,6 +2,7 @@
 using FastColoredTextBoxNS;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -161,7 +162,7 @@ namespace TabularEditor.UI
 
             Handler.Settings = Preferences.Current.GetSettings();
 
-            LastDeploymentDb = null;
+            LastDeploymentDb = Path.GetFileNameWithoutExtension(UIController.Current.File_Current);
 
             UI.FormMain.actToggleFilter.Checked = false;
             //DisableLinqMode();


### PR DESCRIPTION
Variable Lastdeploymentdb is null upon opening, a good educated guess would be the filename of the .bim file.